### PR TITLE
Include a link to open the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Source code accompanying O'Reilly book: <br/>
 
 We will update this repo with source code as we write each chapter. Stay tuned!
 
+[<img src="https://deepnote.com/buttons/try-in-a-jupyter-notebook-white.svg">](https://deepnote.com/launch?url=https://github.com/GoogleCloudPlatform/ml-design-patterns)
+
 # Chapters
 
 * Preface


### PR DESCRIPTION
Hey, I'm reading through the book and thoroughly enjoying it, thanks @lakshmanok! 

I have some trouble viewing the notebooks here on GitHub though (it keeps saying "Sorry, something went wrong", likely hitting some size limits).

I work at Deepnote, and we try to build better data science notebooks. The proposed button opens the repo as a project in Deepnote, and you can view and execute all of the files – it might be helpful for other readers too :)